### PR TITLE
シンボルテーブルにメンバを追加

### DIFF
--- a/src/code_generator/symbol_table.c
+++ b/src/code_generator/symbol_table.c
@@ -52,6 +52,7 @@ SymbolTableRef symbol_table_ctor(StringRef name) {
   const SymbolTableRef table = safe_malloc(struct SymbolTable);
   table->module = LLVMModuleCreateWithName(string_data(name));
   table->builder = LLVMCreateBuilder();
+  table->prefix = string_ctor("", NULL);
   table->stack = VECTORFUNC(SymbolBlockRef, ctor)(NULL);
   return table;
 }
@@ -60,6 +61,7 @@ void symbol_table_dtor(SymbolTableRef* pself) {
   assert(pself);
   LLVMDisposeModule((*pself)->module);
   LLVMDisposeBuilder((*pself)->builder);
+  string_dtor(&(*pself)->prefix);
   {
     const VECTORREF(SymbolBlockRef) vector = (*pself)->stack;
     SymbolBlockRef* iter = VECTORFUNC(SymbolBlockRef, begin)(vector);

--- a/src/code_generator/symbol_table.c
+++ b/src/code_generator/symbol_table.c
@@ -48,14 +48,16 @@ void symbol_block_dtor(SymbolBlockRef* pself) {
   safe_free(*pself);
 }
 
-SymbolTableRef symbol_table_ctor(void) {
+SymbolTableRef symbol_table_ctor(StringRef name) {
   const SymbolTableRef table = safe_malloc(struct SymbolTable);
+  table->module = LLVMModuleCreateWithName(string_data(name));
   table->stack = VECTORFUNC(SymbolBlockRef, ctor)(NULL);
   return table;
 }
 
 void symbol_table_dtor(SymbolTableRef* pself) {
   assert(pself);
+  LLVMDisposeModule((*pself)->module);
   {
     const VECTORREF(SymbolBlockRef) vector = (*pself)->stack;
     SymbolBlockRef* iter = VECTORFUNC(SymbolBlockRef, begin)(vector);

--- a/src/code_generator/symbol_table.c
+++ b/src/code_generator/symbol_table.c
@@ -51,6 +51,7 @@ void symbol_block_dtor(SymbolBlockRef* pself) {
 SymbolTableRef symbol_table_ctor(StringRef name) {
   const SymbolTableRef table = safe_malloc(struct SymbolTable);
   table->module = LLVMModuleCreateWithName(string_data(name));
+  table->builder = LLVMCreateBuilder();
   table->stack = VECTORFUNC(SymbolBlockRef, ctor)(NULL);
   return table;
 }
@@ -58,6 +59,7 @@ SymbolTableRef symbol_table_ctor(StringRef name) {
 void symbol_table_dtor(SymbolTableRef* pself) {
   assert(pself);
   LLVMDisposeModule((*pself)->module);
+  LLVMDisposeBuilder((*pself)->builder);
   {
     const VECTORREF(SymbolBlockRef) vector = (*pself)->stack;
     SymbolBlockRef* iter = VECTORFUNC(SymbolBlockRef, begin)(vector);

--- a/src/code_generator/symbol_table_impl.h
+++ b/src/code_generator/symbol_table_impl.h
@@ -23,6 +23,7 @@ DECLARE_VECTOR(SymbolBlockRef)
 struct SymbolTable {
   LLVMModuleRef module;
   LLVMBuilderRef builder;
+  StringRef prefix;
   VECTORREF(SymbolBlockRef) stack;
 };
 

--- a/src/code_generator/symbol_table_impl.h
+++ b/src/code_generator/symbol_table_impl.h
@@ -21,6 +21,7 @@ struct SymbolBlock {
 DECLARE_VECTOR(SymbolBlockRef)
 
 struct SymbolTable {
+  LLVMModuleRef module;
   VECTORREF(SymbolBlockRef) stack;
 };
 

--- a/src/code_generator/symbol_table_impl.h
+++ b/src/code_generator/symbol_table_impl.h
@@ -22,6 +22,7 @@ DECLARE_VECTOR(SymbolBlockRef)
 
 struct SymbolTable {
   LLVMModuleRef module;
+  LLVMBuilderRef builder;
   VECTORREF(SymbolBlockRef) stack;
 };
 


### PR DESCRIPTION
- シンボルテーブルがモジュールやビルダーを持つようにした。
- `prefix` は現在のスコープの深さを表現する文字列で、LLVM内において変数を区別するためのプリフィックスに用いる。