### PR TITLE
シンボルテーブルを操作する関数を追加

### DIFF
--- a/src/code_generator/symbol_table.c
+++ b/src/code_generator/symbol_table.c
@@ -123,3 +123,34 @@ void register_symbol(StringRef name, LLVMTypeRef type, LLVMValueRef value) {
 void append_prefix(StringRef name) {
   string_insert(name, 0, g_symbol_table->prefix);
 }
+
+static SymbolInfoRef find_symbol_in_block(StringRef name,
+                                          SymbolBlockRef block) {
+  const SymbolInfoRef* const begin =
+      VECTORFUNC(SymbolInfoRef, begin)(block->symbols);
+  const SymbolInfoRef* const end =
+      VECTORFUNC(SymbolInfoRef, end)(block->symbols);
+  const SymbolInfoRef* iter = begin;
+  for (; iter != end; ++iter) {
+    if (string_compare((*iter)->name, name) == 0) {
+      return *iter;
+    }
+  }
+  return NULL;
+}
+
+SymbolInfoRef find_symbol(StringRef name) {
+  const SymbolBlockRef* const begin =
+      VECTORFUNC(SymbolBlockRef, begin)(g_symbol_table->stack);
+  const SymbolBlockRef* const end =
+      VECTORFUNC(SymbolBlockRef, end)(g_symbol_table->stack);
+  const SymbolBlockRef* iter = end;
+  for (; iter != begin; --iter) {
+    const SymbolInfoRef symbol = find_symbol_in_block(name, *(iter - 1));
+    if (symbol) {
+      return symbol;
+    }
+  }
+  /* TODO: find global symbol */
+  return NULL;
+}

--- a/src/code_generator/symbol_table.c
+++ b/src/code_generator/symbol_table.c
@@ -112,3 +112,10 @@ void symbol_table_pop(void) {
     string_erase(g_symbol_table->prefix, i, length - i);
   }
 }
+
+void register_symbol(StringRef name, LLVMTypeRef type, LLVMValueRef value) {
+  const SymbolInfoRef symbol = symbol_info_ctor(name, type, value);
+  const SymbolBlockRef block =
+      VECTORFUNC(SymbolBlockRef, back)(g_symbol_table->stack);
+  VECTORFUNC(SymbolInfoRef, push_back)(block->symbols, symbol);
+}

--- a/src/code_generator/symbol_table.c
+++ b/src/code_generator/symbol_table.c
@@ -119,3 +119,7 @@ void register_symbol(StringRef name, LLVMTypeRef type, LLVMValueRef value) {
       VECTORFUNC(SymbolBlockRef, back)(g_symbol_table->stack);
   VECTORFUNC(SymbolInfoRef, push_back)(block->symbols, symbol);
 }
+
+void append_prefix(StringRef name) {
+  string_insert(name, 0, g_symbol_table->prefix);
+}

--- a/src/code_generator/symbol_table.h
+++ b/src/code_generator/symbol_table.h
@@ -13,5 +13,6 @@ void finalize_symbol_table(void);
 void symbol_table_push(StringRef name);
 void symbol_table_pop(void);
 void register_symbol(StringRef name, LLVMTypeRef type, LLVMValueRef value);
+void append_prefix(StringRef name);
 
 #endif  /* KMC_C90_COMPILER_CODE_GENERATOR_SYMBOL_TABLE_H */

--- a/src/code_generator/symbol_table.h
+++ b/src/code_generator/symbol_table.h
@@ -14,5 +14,6 @@ void symbol_table_push(StringRef name);
 void symbol_table_pop(void);
 void register_symbol(StringRef name, LLVMTypeRef type, LLVMValueRef value);
 void append_prefix(StringRef name);
+SymbolInfoRef find_symbol(StringRef name);
 
 #endif  /* KMC_C90_COMPILER_CODE_GENERATOR_SYMBOL_TABLE_H */

--- a/src/code_generator/symbol_table.h
+++ b/src/code_generator/symbol_table.h
@@ -1,11 +1,15 @@
 #ifndef KMC_C90_COMPILER_CODE_GENERATOR_SYMBOL_TABLE_H
 #define KMC_C90_COMPILER_CODE_GENERATOR_SYMBOL_TABLE_H
 
+#include "stdstring.h"
+
 typedef struct SymbolInfo* SymbolInfoRef;
 typedef struct SymbolBlock* SymbolBlockRef;
 typedef struct SymbolTable* SymbolTableRef;
 
 void initialize_symbol_table(StringRef name);
 void finalize_symbol_table(void);
+void symbol_table_push(StringRef name);
+void symbol_table_pop(void);
 
 #endif  /* KMC_C90_COMPILER_CODE_GENERATOR_SYMBOL_TABLE_H */

--- a/src/code_generator/symbol_table.h
+++ b/src/code_generator/symbol_table.h
@@ -1,6 +1,7 @@
 #ifndef KMC_C90_COMPILER_CODE_GENERATOR_SYMBOL_TABLE_H
 #define KMC_C90_COMPILER_CODE_GENERATOR_SYMBOL_TABLE_H
 
+#include <llvm-c/Core.h>
 #include "stdstring.h"
 
 typedef struct SymbolInfo* SymbolInfoRef;
@@ -11,5 +12,6 @@ void initialize_symbol_table(StringRef name);
 void finalize_symbol_table(void);
 void symbol_table_push(StringRef name);
 void symbol_table_pop(void);
+void register_symbol(StringRef name, LLVMTypeRef type, LLVMValueRef value);
 
 #endif  /* KMC_C90_COMPILER_CODE_GENERATOR_SYMBOL_TABLE_H */


### PR DESCRIPTION
- `symbol_table_push`
  - シンボルテーブルに新しいスコープを導入する。
- `symbol_table_pop`
  - スコープを一つ抜ける。
- `register_symbol`
  - 現在のスコープにシンボルを登録する。
- `append_prefix`
  - 現在のプリフィックスを変数名に追加する。
- `find_symbol`
  - 変数名をスコープを遡って探索する。
